### PR TITLE
Issue 2/logging tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.venv/
+logs/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ export CAMERA_SOURCE=http://host.docker.internal:8080/video.mjpg
 python3 src/main.py
 ```
 
+Runtime logs are written to `logs/aether-system.log` and also mirrored to the console.
+
 ## Webcam on Linux with devcontainer
 
 On Linux, `CAMERA_SOURCE=0` only works if the camera device is passed into the

--- a/src/aether_logger.py
+++ b/src/aether_logger.py
@@ -1,0 +1,62 @@
+import atexit
+import logging
+import os
+from pathlib import Path
+
+
+# Guard to ensure logging.shutdown() is registered with atexit only once,
+# even if setup_logger() is called multiple times across different modules.
+_LOGGING_SHUTDOWN_REGISTERED = False
+
+
+def _resolve_level(level_name: str) -> int:
+    # Convert a level name string (e.g. "DEBUG") to its logging int constant.
+    # Falls back to INFO if the name is unrecognized.
+    return getattr(logging, level_name.upper(), logging.INFO)
+
+
+def setup_logger(log_filename: str, logger_name: str) -> logging.Logger:
+    global _LOGGING_SHUTDOWN_REGISTERED
+
+    # Return the existing logger if it has already been configured.
+    # This prevents duplicate handlers when setup_logger() is called again
+    # with the same logger_name (e.g. on module reload).
+    logger = logging.getLogger(logger_name)
+    if logger.handlers:
+        return logger
+
+    # Allow log level to be overridden at runtime via environment variable.
+    log_level = _resolve_level(os.getenv("AETHER_LOG_LEVEL", "INFO"))
+
+    # Resolve the logs/ directory relative to the project root, regardless of
+    # where the process is launched from.
+    logs_dir = Path(__file__).resolve().parent.parent / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / log_filename
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] [%(name)s] %(message)s"
+    )
+
+    # Write logs to file for post-run analysis.
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    # Mirror logs to console for real-time monitoring.
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    logger.setLevel(log_level)
+    # Disable propagation to the root logger to avoid duplicate log entries
+    # when other libraries also attach handlers to the root.
+    logger.propagate = False
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+
+    # Flush and close all handlers on program exit so no log records are lost.
+    if not _LOGGING_SHUTDOWN_REGISTERED:
+        atexit.register(logging.shutdown)
+        _LOGGING_SHUTDOWN_REGISTERED = True
+
+    logger.info("Logging initialized. Writing to %s", log_path)
+    return logger

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,77 @@
-#include "main.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "logging/log.h"
+
+/* File handle for the log file, kept open for the lifetime of the process. */
+static FILE *g_log_file = NULL;
+
+/* Create the logs/ directory if it does not already exist. */
+static int ensure_log_directory(void) {
+    if (mkdir("logs", 0755) == 0 || errno == EEXIST) {
+        return 0;
+    }
+
+    fprintf(stderr, "Failed to create logs directory: %s\n", strerror(errno));
+    return -1;
+}
+
+/* Flush and close the log file. Registered with atexit() so it runs
+ * automatically when the process exits, ensuring no log records are lost. */
+static void close_log_file(void) {
+    if (g_log_file != NULL) {
+        fflush(g_log_file);
+        fclose(g_log_file);
+        g_log_file = NULL;
+    }
+}
+
+/* Initialize the logging system.
+ * Opens logs/aether-system.log in append mode and registers it as a
+ * file callback with the rxi/log library (log.h). Also registers
+ * close_log_file() via atexit() to flush and close the file on exit.
+ * Returns 0 on success, -1 on failure. */
+static int setup_logging(void) {
+    if (ensure_log_directory() != 0) {
+        return -1;
+    }
+
+    /* Open in append mode so logs from multiple runs are preserved. */
+    g_log_file = fopen("logs/aether-system.log", "a");
+    if (g_log_file == NULL) {
+        fprintf(stderr, "Failed to open logs/aether-system.log: %s\n", strerror(errno));
+        return -1;
+    }
+
+    if (log_add_fp(g_log_file, LOG_TRACE) != 0) {
+        fprintf(stderr, "Failed to register file logger callback.\n");
+        close_log_file();
+        return -1;
+    }
+
+    /* Ensure the log file is flushed and closed on normal program exit. */
+    atexit(close_log_file);
+    log_set_level(LOG_TRACE);
+    log_info("C logger initialized. Writing to logs/aether-system.log");
+    return 0;
+}
 
 int print_hello() {
-    printf("Hello, World!\n");
+    log_info("Hello, World!");
     return 0;
 }
 
 int main() {
+    if (setup_logging() != 0) {
+        return 1;
+    }
+
+    log_info("Starting C entrypoint.");
     print_hello();
+    log_info("C entrypoint shutdown complete.");
     return 0;
 }

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,10 @@ import mediapipe as mp
 import numpy as np
 from mediapipe.tasks import python
 from mediapipe.tasks.python import vision
+from aether_logger import setup_logger
+
+
+logger = setup_logger('aether-system.log', 'AETHER.VISION')
 
 # Hand Connections
 HAND_CONNECTIONS = [
@@ -20,6 +24,13 @@ HAND_CONNECTIONS = [
     (13, 17), (17, 18), (18, 19), (19, 20), # Pinky
     (0, 17),                                # Palm to Pinky Base
 ]
+
+
+def is_headless_environment():
+    # macOS native OpenCV windows do not require DISPLAY, unlike Linux/X11 setups.
+    if os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin':
+        return False
+    return not os.getenv('DISPLAY')
 
 
 def resolve_camera_source():
@@ -45,14 +56,14 @@ def open_camera_capture(camera_source):
     for backend_name, backend in candidates:
         cap = cv2.VideoCapture(camera_source, backend)
         if cap.isOpened():
-            print(f"Opened camera source with backend={backend_name}")
+            logger.info("Opened camera source with backend=%s", backend_name)
             return cap
         cap.release()
 
     # Final fallback for environments where backend argument is ignored.
     cap = cv2.VideoCapture(camera_source)
     if cap.isOpened():
-        print("Opened camera source with backend=DEFAULT")
+        logger.info("Opened camera source with backend=DEFAULT")
         return cap
 
     return cap
@@ -106,7 +117,7 @@ class LatestFrameReader:
     def _warn_throttled(self, message):
         now = time.monotonic()
         if now - self._last_warn_at > 2.0:
-            print(message)
+            logger.warning(message)
             self._last_warn_at = now
 
     def _run_mjpeg_url(self):
@@ -184,115 +195,150 @@ def draw_hand_landmarks(image, detection_result):
     return image
 
 
-# Model path
-model_path = os.path.join(os.path.dirname(__file__), '..', 'model', 'hand_landmarker.task')
+def main():
+    logger.info("Starting Aether vision pipeline.")
 
-# Reset MediaPipe HandLandmarker (Tasks API)
-# https://ai.google.dev/mediapipe/solutions/vision/hand_landmarker
-base_options = python.BaseOptions(model_asset_path=model_path)
-options = vision.HandLandmarkerOptions(
-    base_options=base_options,
-    num_hands=2,
-    min_hand_detection_confidence=0.5,
-    min_hand_presence_confidence=0.5,
-    min_tracking_confidence=0.5,
-    running_mode=vision.RunningMode.VIDEO,
-)
-detector = vision.HandLandmarker.create_from_options(options)
+    model_path = os.path.join(os.path.dirname(__file__), '..', 'model', 'hand_landmarker.task')
+    detector = None
+    reader = None
 
-# Start video capture
-camera_source = resolve_camera_source()
-cap = None
+    try:
+        # Reset MediaPipe HandLandmarker (Tasks API)
+        # https://ai.google.dev/mediapipe/solutions/vision/hand_landmarker
+        base_options = python.BaseOptions(model_asset_path=model_path)
+        options = vision.HandLandmarkerOptions(
+            base_options=base_options,
+            num_hands=2,
+            min_hand_detection_confidence=0.5,
+            min_hand_presence_confidence=0.5,
+            min_tracking_confidence=0.5,
+            running_mode=vision.RunningMode.VIDEO,
+        )
+        detector = vision.HandLandmarker.create_from_options(options)
+        logger.info("MediaPipe HandLandmarker initialized with model=%s", model_path)
 
-if isinstance(camera_source, int):
-    cap = open_camera_capture(camera_source)
+        camera_source = resolve_camera_source()
+        cap = None
+        headless = is_headless_environment()
 
-if isinstance(camera_source, int) and not cap.isOpened():
-    if isinstance(camera_source, int):
-        device_path = f"/dev/video{camera_source}"
-        visible_devices = ", ".join(sorted(glob.glob('/dev/video*'))) or "none"
+        if headless:
+            logger.info("No DISPLAY detected. Running in headless mode without OpenCV windows.")
 
-        if not os.path.exists(device_path):
+        if isinstance(camera_source, int):
+            cap = open_camera_capture(camera_source)
+
+        if isinstance(camera_source, int) and not cap.isOpened():
+            device_path = f"/dev/video{camera_source}"
+            visible_devices = ", ".join(sorted(glob.glob('/dev/video*'))) or "none"
+
+            if not os.path.exists(device_path):
+                raise RuntimeError(
+                    "Failed to open camera source: "
+                    f"{camera_source}. "
+                    f"{device_path} is not available in this container. "
+                    f"Visible camera devices: {visible_devices}. "
+                    "If you are running in a Linux devcontainer, pass through your camera "
+                    "with run args like `--device=/dev/video0:/dev/video0` "
+                    "(optionally `--group-add=video`) and rebuild the container, "
+                    "or use a stream URL for CAMERA_SOURCE."
+                )
+
             raise RuntimeError(
                 "Failed to open camera source: "
                 f"{camera_source}. "
-                f"{device_path} is not available in this container. "
-                f"Visible camera devices: {visible_devices}. "
-                "If you are running in a Linux devcontainer, pass through your camera "
-                "with run args like `--device=/dev/video0:/dev/video0` "
-                "(optionally `--group-add=video`) and rebuild the container, "
-                "or use a stream URL for CAMERA_SOURCE."
+                "Set CAMERA_SOURCE to an index (e.g. 0) or stream URL "
+                "(e.g. http://host.docker.internal:8080/video.mjpg)."
             )
 
-    raise RuntimeError(
-        "Failed to open camera source: "
-        f"{camera_source}. "
-        "Set CAMERA_SOURCE to an index (e.g. 0) or stream URL "
-        "(e.g. http://host.docker.internal:8080/video.mjpg)."
-    )
+        logger.info("Using CAMERA_SOURCE=%s", camera_source)
+        reader = LatestFrameReader(camera_source, cap=cap)
+        reader.start()
+        logger.info("Frame reader started.")
 
-print(f"Using CAMERA_SOURCE={camera_source}")
-reader = LatestFrameReader(camera_source, cap=cap)
-reader.start()
-
-timestamp_ms = 0
-black_frame_count = 0
-waiting_warned = False
-placeholder = np.zeros((480, 640, 3), dtype=np.uint8)
-
-while True:
-    image, latest_ts = reader.get_latest()
-
-    if image is None:
-        status = placeholder.copy()
-        cv2.putText(status, 'Waiting for camera frames...', (30, 240), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 255, 255), 2)
-        cv2.imshow('MediaPipe Hands', status)
-        if cv2.waitKey(1) & 0xFF == 27:
-            break
-        continue
-
-    # Surface stale stream status without blocking UI interaction.
-    frame_age = time.monotonic() - latest_ts
-    if frame_age > 1.0 and not waiting_warned:
-        print('Warning: frame stream appears stale (>1s).')
-        waiting_warned = True
-    if frame_age <= 1.0:
+        timestamp_ms = 0
+        black_frame_count = 0
         waiting_warned = False
+        placeholder = np.zeros((480, 640, 3), dtype=np.uint8)
 
-    # Detect persistent blank stream frames and provide actionable guidance.
-    if image is not None and image.size > 0:
-        if float(image.mean()) < 2.0:
-            black_frame_count += 1
-        else:
-            black_frame_count = 0
+        while True:
+            image, latest_ts = reader.get_latest()
 
-    if black_frame_count == 45:
-        print(
-            "Warning: received many near-black frames from CAMERA_SOURCE. "
-            "If using host stream, verify host preview at http://localhost:8080/ "
-            "and try another host camera index."
-        )
+            if image is None:
+                if not headless:
+                    status = placeholder.copy()
+                    cv2.putText(status, 'Waiting for camera frames...', (30, 240), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 255, 255), 2)
+                    cv2.imshow('MediaPipe Hands', status)
+                    if cv2.waitKey(1) & 0xFF == 27:
+                        logger.info("ESC pressed while waiting for camera frames.")
+                        break
+                else:
+                    time.sleep(0.01)
+                continue
 
-    # For local cameras mirror the image; host-side stream is already mirrored.
-    if isinstance(camera_source, int):
-        image = cv2.flip(image, 1)
+            # Surface stale stream status without blocking UI interaction.
+            frame_age = time.monotonic() - latest_ts
+            if frame_age > 1.0 and not waiting_warned:
+                logger.warning('Frame stream appears stale (>1s).')
+                waiting_warned = True
+            if frame_age <= 1.0:
+                waiting_warned = False
 
-    # BGR to RGB conversion for MediaPipe
-    rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb_image)
+            # Detect persistent blank stream frames and provide actionable guidance.
+            if image.size > 0:
+                if float(image.mean()) < 2.0:
+                    black_frame_count += 1
+                else:
+                    black_frame_count = 0
 
-    # Hand detection timestamp must be strictly increasing.
-    now_ms = int(time.monotonic() * 1000)
-    timestamp_ms = max(timestamp_ms + 1, now_ms)
-    detection_result = detector.detect_for_video(mp_image, timestamp_ms)
+            if black_frame_count == 45:
+                logger.warning(
+                    "Received many near-black frames from CAMERA_SOURCE. "
+                    "If using host stream, verify host preview at http://localhost:8080/ "
+                    "and try another host camera index."
+                )
 
-    # Draw landmarks on the original image
-    image = draw_hand_landmarks(image, detection_result)
+            # For local cameras mirror the image; host-side stream is already mirrored.
+            if isinstance(camera_source, int):
+                image = cv2.flip(image, 1)
 
-    cv2.imshow('MediaPipe Hands', image)
-    if cv2.waitKey(1) & 0xFF == 27:  # Exit on 'ESC' key
-        break
+            # BGR to RGB conversion for MediaPipe
+            rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb_image)
 
-reader.stop()
-cv2.destroyAllWindows()
-detector.close()
+            # Hand detection timestamp must be strictly increasing.
+            now_ms = int(time.monotonic() * 1000)
+            timestamp_ms = max(timestamp_ms + 1, now_ms)
+            detection_result = detector.detect_for_video(mp_image, timestamp_ms)
+
+            # Draw landmarks on the original image
+            image = draw_hand_landmarks(image, detection_result)
+
+            if not headless:
+                cv2.imshow('MediaPipe Hands', image)
+                if cv2.waitKey(1) & 0xFF == 27:  # Exit on 'ESC' key
+                    logger.info("ESC pressed. Exiting vision loop.")
+                    break
+
+        logger.info("Vision loop exited normally.")
+        return 0
+    except KeyboardInterrupt:
+        logger.info("Keyboard interrupt received. Shutting down vision pipeline.")
+        return 0
+    except Exception:
+        logger.exception("Vision pipeline terminated due to an unexpected error.")
+        return 1
+    finally:
+        if reader is not None:
+            reader.stop()
+            logger.info("Frame reader stopped.")
+        if detector is not None:
+            detector.close()
+            logger.info("HandLandmarker closed.")
+        if not is_headless_environment():
+            cv2.destroyAllWindows()
+            logger.info("OpenCV windows destroyed.")
+        logger.info("Aether vision pipeline shutdown complete.")
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Description
Set up the logging tool for both Python and C.
- Added `aether_logger.py` as a reusable Python logging module that writes to both console and `logs/aether-system.log`
- Integrated the logger into `src/main.py`, replacing all `print()` calls
- Set up C logging in `src/main.c` using the rxi/log library (`src/logging/log.h`), also writing to `logs/aether-system.log`
- Updated example code in `logging_tool.md` to match the actual implementation
- Added `.venv/` and `logs/` to `.gitignore`

## Related Issue or the ticket that you have been assigned (e.g fixes or closes #number-of-issue)
- #2 

## Type of sections
- [x] Computer Vision Node
- [ ] ROS 2 Communication
- [ ] Gazebo Simulation
- [ ] Socket Communication
- [ ] Firmware
- [ ] Mechanical Design
- [ ] Electrical Design
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Environment
- **Host OS:** macOS
- **Container:** - [x] Tested inside the standard Dev Container
- **Hardware:**
  - [ ] Tested with physical webcam
  - [ ] Tested with physical robot arm (Socket Comm)

## Testing (Explain testing approaches)
- Ran `python3 src/main.py` inside the Dev Container
- Verified that `logs/aether-system.log` is created automatically on startup                       - Confirmed log entries are written in the correct format: `timestamp [LEVEL] [module] message`
- Confirmed all shutdown logs are written correctly after `Ctrl+C`

## Screenshots (if applicable)
<img width="920" height="764" alt="스크린샷 2026-04-07 오후 9 48 58" src="https://github.com/user-attachments/assets/6b0e739b-0838-463d-a318-5bc6c776761a" />