### PR TITLE
feat: add MultiHandTracker module for left/right hand tracking

### DIFF
--- a/src/MultiHandTracker.py
+++ b/src/MultiHandTracker.py
@@ -1,0 +1,192 @@
+"""
+MultiHandTracker.py — Issue #40: Multi-Hand Support
+
+Tracks left and right hands independently across frames.
+Import this into main.py — do not modify main.py's core logic.
+
+Usage:
+    from MultiHandTracker import MultiHandTracker, HandSide
+
+    tracker = MultiHandTracker()                               # both hands
+    tracker = MultiHandTracker(dominant_hand=HandSide.RIGHT)   # right only
+    tracker = MultiHandTracker(is_mirrored=True)               # webcam (flipped)
+
+    # every frame:
+    tracker.update(detection_result)
+"""
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger('AETHER.VISION')
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+# At 30fps, 10 frames ≈ 0.3s
+HAND_DISAPPEAR_FRAME_THRESHOLD = 10
+
+# Frames required to lock a hand's side on first detection.
+# Once locked, side never changes until the hand disappears.
+SIDE_LOCK_FRAMES = 8
+
+
+# ── Data types ────────────────────────────────────────────────────────────────
+
+class HandSide(Enum):
+    LEFT  = "Left"
+    RIGHT = "Right"
+
+
+class HandState:
+    """Current state of a single tracked hand."""
+
+    def __init__(self, landmarks):
+        self.side: HandSide | None          = None
+        self.landmarks                      = landmarks
+        self.missing_frames                 = 0
+        self._lock_history: list[HandSide]  = []
+        self._locked                        = False
+
+    def try_lock_side(self, raw: HandSide) -> bool:
+        """Accumulate raw guesses. Returns True once side is locked."""
+        if self._locked:
+            return True
+        self._lock_history.append(raw)
+        if len(self._lock_history) >= SIDE_LOCK_FRAMES:
+            left  = self._lock_history.count(HandSide.LEFT)
+            right = self._lock_history.count(HandSide.RIGHT)
+            self.side    = HandSide.LEFT if left >= right else HandSide.RIGHT
+            self._locked = True
+            logger.info("%s hand confirmed and locked", self.side.value)
+        return self._locked
+
+    def update(self, landmarks) -> None:
+        self.landmarks      = landmarks
+        self.missing_frames = 0
+
+    def mark_missing(self) -> None:
+        self.missing_frames += 1
+
+    @property
+    def is_locked(self) -> bool:
+        return self._locked
+
+    @property
+    def is_confirmed_gone(self) -> bool:
+        return self.missing_frames >= HAND_DISAPPEAR_FRAME_THRESHOLD
+
+
+# ── Tracker ───────────────────────────────────────────────────────────────────
+
+class MultiHandTracker:
+    """Manages detection and tracking of multiple hands across frames.
+
+    Side detection
+    --------------
+    Uses MediaPipe's handedness classification (not landmark geometry),
+    which correctly identifies Left/Right regardless of whether the palm
+    or back of the hand faces the camera.
+
+    If is_mirrored=True (webcam with cv2.flip), the handedness label is
+    flipped to compensate — MediaPipe sees the pre-flip image so its
+    Left/Right is the mirror of what the user sees.
+
+    Side-locking
+    ------------
+    Once a hand's side is confirmed over SIDE_LOCK_FRAMES frames, it
+    never changes while the hand is visible.  The lock releases only when
+    the hand disappears for HAND_DISAPPEAR_FRAME_THRESHOLD frames.
+    """
+
+    def __init__(self,
+                 dominant_hand: HandSide | None = None,
+                 is_mirrored: bool = False):
+        """
+        Parameters
+        ----------
+        dominant_hand : HandSide or None
+            Filter to one hand. None = track both.
+        is_mirrored : bool
+            True if the frame is flipped with cv2.flip (typical webcam setup).
+            Flips the MediaPipe handedness label to match what the user sees.
+        """
+        self.dominant_hand = dominant_hand
+        self.is_mirrored   = is_mirrored
+        self._slots: dict[int, HandState]    = {}
+        self._hands: dict[HandSide, HandState] = {}
+
+    # ── Configuration ─────────────────────────────────────────────────────────
+
+    def set_dominant_hand(self, side: HandSide | None) -> None:
+        self.dominant_hand = side
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _get_side(self, handedness) -> HandSide:
+        """Read side from MediaPipe handedness, flipping if mirrored."""
+        label = handedness[0].category_name  # "Left" or "Right"
+        side  = HandSide.LEFT if label == "Left" else HandSide.RIGHT
+        if self.is_mirrored:
+            side = HandSide.RIGHT if side == HandSide.LEFT else HandSide.LEFT
+        return side
+
+    def _should_track(self, side: HandSide) -> bool:
+        return self.dominant_hand is None or side == self.dominant_hand
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def update(self, detection_result) -> None:
+        """Process one frame of MediaPipe detection results."""
+        active_slots: set[int] = set()
+
+        for slot, (hand_landmarks, handedness) in enumerate(
+            zip(detection_result.hand_landmarks, detection_result.handedness)
+        ):
+            raw = self._get_side(handedness)
+            active_slots.add(slot)
+
+            if slot not in self._slots:
+                self._slots[slot] = HandState(hand_landmarks)
+
+            state = self._slots[slot]
+            state.update(hand_landmarks)
+            newly_locked = state.try_lock_side(raw)
+
+            if newly_locked and state.side not in self._hands:
+                if self._should_track(state.side):
+                    self._hands[state.side] = state
+
+        # Age out slots not seen this frame
+        for slot in list(self._slots):
+            if slot in active_slots:
+                continue
+
+            state = self._slots[slot]
+            state.mark_missing()
+
+            if state.is_confirmed_gone:
+                if state.side and state.side in self._hands:
+                    del self._hands[state.side]
+                    logger.info("%s hand removed after %d missing frames",
+                                state.side.value, HAND_DISAPPEAR_FRAME_THRESHOLD)
+                del self._slots[slot]
+            else:
+                logger.debug("slot %d (%s) occluded — holding (%d/%d)",
+                             slot,
+                             state.side.value if state.side else "unlocked",
+                             state.missing_frames,
+                             HAND_DISAPPEAR_FRAME_THRESHOLD)
+
+    def get_active_hands(self) -> list[HandState]:
+        return list(self._hands.values())
+
+    def get_hand(self, side: HandSide) -> HandState | None:
+        return self._hands.get(side)
+
+    def is_hand_present(self, side: HandSide) -> bool:
+        return side in self._hands
+
+    def get_dominant_hand_state(self) -> HandState | None:
+        if self.dominant_hand is None:
+            return None
+        return self._hands.get(self.dominant_hand)

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from mediapipe.tasks import python
 from mediapipe.tasks.python import vision
 from aether_logger import setup_logger
 from z_coordinate import label_z_coordinate
-
+from MultiHandTracker import MultiHandTracker, HandSide
 
 logger = setup_logger('aether-system.log', 'AETHER.VISION')
 
@@ -217,6 +217,7 @@ def main():
         )
         detector = vision.HandLandmarker.create_from_options(options)
         logger.info("MediaPipe HandLandmarker initialized with model=%s", model_path)
+        tracker = MultiHandTracker(is_mirrored=True)
 
         camera_source = resolve_camera_source()
         cap = None
@@ -313,6 +314,7 @@ def main():
             now_ms = int(time.monotonic() * 1000)
             timestamp_ms = max(timestamp_ms + 1, now_ms)
             detection_result = detector.detect_for_video(mp_image, timestamp_ms)
+            tracker.update(detection_result)
 
             # Draw landmarks on the original image
             image = draw_hand_landmarks(image, detection_result)


### PR DESCRIPTION
## Description
Added `MultiHandTracker.py` as a standalone module to support simultaneous detection and independent tracking of left and right hands.

## Related Issue or the ticket that you have been assigned (e.g fixes or closes #number-of-issue)
Closes #40

## Type of sections
- [✓] Computer Vision Node
- [ ] ROS 2 Communication
- [ ] Gazebo Simulation
- [ ] Socket Communication
- [ ] Firmware
- [ ] Mechanical Design
- [ ] Electrical Design
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Environment
- **Host OS:** (e.g., Ubuntu 22.04, Windows 11 with WSL2, macOS) - Windows 11 with WSL2
- **Container:** - [✓] Tested inside the standard Dev Container
- **Hardware:**
  - [✓] Tested with physical webcam
  - [ ] Tested with physical robot arm (Socket Comm)

## Testing (Explain testing approaches)
- Verified left and right hands are correctly identified when both are visible simultaneously
- Confirmed side label does not flip when wrist is rotated to show the back of the hand
- Confirmed that removing one hand from frame does not cause the remaining hand to be mislabeled
- Verified occluded hand state is held for ~0.3s (10 frames) before being dropped
- Tested with `is_mirrored=True` (webcam) — handedness label correctly compensates for horizontal flip

## Screenshots (if applicable)