### PR TITLE
add motion smoothing module (XYZSmoother)

### DIFF
--- a/src/main2.py
+++ b/src/main2.py
@@ -19,6 +19,7 @@ from MultiHandTracker import HandSide, MultiHandTracker
 from WristDetection import calibrate_wrist_base, compute_wrist_state
 from aether_logger import setup_logger
 from base_rotation import base_rotation_x, border_box, get_base_rotation_direction
+from smoothing import GrabDebouncer, WristSmoother, XYZSmoother
 
 #cd /Users/admin/Aether
 #source .host-venv/bin/activate
@@ -221,9 +222,9 @@ def draw_xy_coordinates_for_hand(image, xy_coordinates, color=(255, 0, 0)):
 
     hand_x = xy_coordinates["pixel_x"]
     hand_y = xy_coordinates["pixel_y"]
-    text = f"XYZ: {xy_coordinates['x']}, {xy_coordinates['y']}, {xy_coordinates.get('z', '-')}"
+    text = f"(X,Y): {xy_coordinates['x']}, {xy_coordinates['y']}"
     cv2.circle(image, (hand_x, hand_y), 8, color, -1)
-    cv2.putText(image, text, (hand_x + 12, hand_y), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+    cv2.putText(image, text, (hand_x + 12, hand_y), cv2.FONT_HERSHEY_SIMPLEX, 0.75, color, 2)
     return image
 
 
@@ -259,10 +260,10 @@ def draw_z_overlay(image, z_coordinate, z_box):
 
     min_x, min_y, max_x, max_y = z_box
     if z_coordinate is None:
-        cv2.putText(image, "Press 'r' to set right-hand Z=0", (min_x, max(20, min_y - 10)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+        cv2.putText(image, "Press 'R' to set right-hand Z=0", (min_x, max(20, min_y - 10)), cv2.FONT_HERSHEY_SIMPLEX, 0.75, (255, 255, 255), 2)
     else:
-        cv2.putText(image, f"Z: {z_coordinate}", (min_x, max(20, min_y - 10)), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 255), 2)
-        cv2.rectangle(image, (min_x, min_y), (max_x, max_y), (255, 0, 0), 2)
+        cv2.putText(image, f"Z: {z_coordinate}", (min_x, max(20, min_y - 10)), cv2.FONT_HERSHEY_SIMPLEX, 0.75, (0, 255, 255), 2)
+        cv2.rectangle(image, (min_x, min_y), (max_x, max_y), (255, 50, 50), 2)
     return image
 
 
@@ -275,7 +276,7 @@ def get_hand_label_position(image, hand_landmarks):
 
 def draw_hand_name(image, hand_name, hand_landmarks, color):
     label_x, label_y = get_hand_label_position(image, hand_landmarks)
-    cv2.putText(image, hand_name, (label_x - 45, label_y), cv2.FONT_HERSHEY_SIMPLEX, 0.7, color, 2)
+    cv2.putText(image, hand_name, (label_x - 45, label_y - 45), cv2.FONT_HERSHEY_SIMPLEX, 1.0, color, 2)
 
 
 def draw_top_summary(image, summary_lines):
@@ -353,6 +354,11 @@ def main():
         left_hand_base_roll = None
         left_hand_base_pitch = None
 
+        # --- Motion smoothing (see src/smoothing.py) ---
+        xyz_smoother   = XYZSmoother()    # EMA for right-hand X, Y, Z
+        wrist_smoother = WristSmoother()  # EMA for left-hand roll/pitch
+        grab_debouncer = GrabDebouncer()  # debounce for left-hand grab
+
         while True:
             image, latest_ts = reader.get_latest()
 
@@ -406,16 +412,19 @@ def main():
             right_z = None
             right_z_box = None
             right_base_rotation = "No hand"
+            raw_right_xyz = None      # raw (pre-smoothing) for comparison output
 
             left_xy = None
             left_grab = "No hand"
             left_wrist = None
             left_base_rotation = "No hand"
+            raw_left_grab = "No hand" # raw (pre-debounce) for comparison output
+            raw_left_wrist = None     # raw (pre-EMA) for comparison output
 
             if right_state is not None:
                 right_hand = right_state.landmarks
                 draw_hand_landmarks(image, right_hand)
-                draw_hand_name(image, "Right Hand", right_hand, (255, 120, 120))
+                draw_hand_name(image, "Right Hand", right_hand, (255, 50, 50))
 
                 right_xyz = extract_xy_coordinates_for_hand(image, right_hand)
                 right_z, right_hand_z_base, right_z_box = extract_z_coordinate_for_hand(
@@ -427,13 +436,23 @@ def main():
 
                 if right_xyz is not None:
                     right_xyz["z"] = right_z
+                    raw_right_xyz = {k: right_xyz[k] for k in ("x", "y", "z")}  # snapshot before EMA
+                    right_xyz = xyz_smoother.update(right_xyz)  # apply EMA smoothing
                     right_base_rotation = get_base_rotation_direction(right_xyz)
-                    image = draw_xy_coordinates_for_hand(image, right_xyz, color=(255, 0, 0))
+                    image = draw_xy_coordinates_for_hand(image, right_xyz, color=(255, 50, 50))
                     base_rotation_x(right_xyz, image)
 
                 image = draw_z_overlay(image, right_z, right_z_box)
             else:
-                cv2.putText(image, "Right Hand not detected", (20, image.shape[0] - 90), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+                xyz_smoother.reset()  # discard history when hand leaves frame
+
+            # pre-initialize so summary_lines inside the block can reference these safely
+            if left_state is None:
+                grab_debouncer.reset()  # discard history when hand leaves frame
+                wrist_smoother.reset()
+
+            left_wrist_lr = left_wrist["roll_direction"] if left_wrist else "Not calibrated"
+            left_wrist_ud = left_wrist["pitch_direction"] if left_wrist else "Not calibrated"
 
             if left_state is not None:
                 left_hand = left_state.landmarks
@@ -441,20 +460,72 @@ def main():
                 draw_hand_name(image, "Left Hand", left_hand, (120, 220, 255))
 
                 left_xy = extract_xy_coordinates_for_hand(image, left_hand)
-                left_base_rotation = get_base_rotation_direction(left_xy)
+
                 if left_xy is not None:
+                    left_base_rotation = get_base_rotation_direction(left_xy)
                     base_rotation_x(left_xy, image)
 
-                left_grab = "Grabbing" if is_grabbing(left_hand) else "Open"
+                    raw_is_grabbing = is_grabbing(left_hand)
+                    raw_left_grab = "Grabbing" if raw_is_grabbing else "Open"  # snapshot before debounce
+                    left_grab = grab_debouncer.update(raw_is_grabbing)         # debounced grab
+                    middle_base = left_hand[9]  # middle finger landmark
+
+                    text_x = int(middle_base.x * image.shape[1]) - 175
+                    text_y = int(middle_base.y * image.shape[0]) - 25
+
+                if left_hand_base_roll is None or left_hand_base_pitch is None:
+                    cv2.putText(
+                        image,
+                        "Press 'B' to set left wrist base",
+                        (text_x, text_y),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.75,
+                        (255, 255, 255),
+                        2
+                    )
+                else:
+                    cv2.putText(
+                        image,
+                        "B = reset left wrist base",
+                        (text_x, text_y),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.75,
+                        (255, 255, 255),
+                        2
+                    )
+
                 if left_hand_base_roll is not None and left_hand_base_pitch is not None:
-                    left_wrist = compute_wrist_state(
+                    raw_wrist = compute_wrist_state(
                         left_hand,
                         "Left",
                         left_hand_base_roll,
                         left_hand_base_pitch,
                     )
-            else:
-                cv2.putText(image, "Left Hand not detected", (20, image.shape[0] - 60), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+                    raw_left_wrist = {                                       # snapshot before EMA
+                        "roll_delta":      raw_wrist["roll_delta"],
+                        "pitch_delta":     raw_wrist["pitch_delta"],
+                        "roll_direction":  raw_wrist["roll_direction"],
+                        "pitch_direction": raw_wrist["pitch_direction"],
+                    }
+                    left_wrist = wrist_smoother.update(raw_wrist)           # apply EMA to roll/pitch
+
+                summary_lines = [
+                    f"Grab: {left_grab}",
+                    f"LR: {left_wrist_lr}",
+                    f"UD: {left_wrist_ud}"
+                ]
+
+                if left_state is not None:
+                    for i, line in enumerate(summary_lines):
+                        cv2.putText(
+                            image,
+                            line,
+                            (20, 40 + i * 35),   # top-left position
+                            cv2.FONT_HERSHEY_SIMPLEX,
+                            0.8,
+                            (255, 255, 255),
+                            2
+                        )
 
             left_wrist_lr = left_wrist["roll_direction"] if left_wrist else "Not calibrated"
             left_wrist_ud = left_wrist["pitch_direction"] if left_wrist else "Not calibrated"
@@ -495,6 +566,20 @@ def main():
                     "xyz": right_xyz,
                     "base_rotation": right_base_rotation,
                 },
+                # Raw (pre-smoothing) values for debugging and tuning.
+                # Suppress with: export LOG_RAW=false
+                "raw": {
+                    "right_hand": {"xyz": raw_right_xyz},
+                    "left_hand": {
+                        "grab": raw_left_grab,
+                        "wrist": {
+                            "up_down": raw_left_wrist["pitch_direction"] if raw_left_wrist else "Not calibrated",
+                            "left_right_rotation": raw_left_wrist["roll_direction"] if raw_left_wrist else "Not calibrated",
+                            "roll_delta": round(raw_left_wrist["roll_delta"], 2) if raw_left_wrist else None,
+                            "pitch_delta": round(raw_left_wrist["pitch_delta"], 2) if raw_left_wrist else None,
+                        },
+                    },
+                } if os.getenv("LOG_RAW", "true").lower() != "false" else None,
             }
             print(json.dumps(terminal_state), flush=True)
 

--- a/src/smoothing.py
+++ b/src/smoothing.py
@@ -1,0 +1,229 @@
+"""
+smoothing.py — Motion smoothing for Aether hand-tracking output.
+
+Implements two complementary strategies:
+
+  1. EMA (Exponential Moving Average) for continuous numeric values
+     (XYZ coordinates, wrist roll/pitch angles).
+
+       smoothed = alpha * raw + (1 - alpha) * previous_smoothed
+
+     alpha ∈ (0, 1]:
+       • High alpha (e.g. 0.8) → fast response, less smoothing
+       • Low  alpha (e.g. 0.2) → heavy smoothing, more lag
+
+     Default: ALPHA_XYZ = 0.3, ALPHA_WRIST = 0.4
+     (wrist uses a slightly higher alpha because its downstream consumer,
+      classify_roll/classify_pitch, already applies a threshold dead-zone,
+      so it can tolerate slightly less pre-smoothing)
+
+  2. Debounce for binary/discrete signals (grab open/close).
+     A state change is only confirmed after it holds for N consecutive
+     frames, suppressing single-frame flickering.
+
+     Default: GRAB_DEBOUNCE_FRAMES = 3
+
+All parameters are exposed as module-level constants so they can be
+adjusted from main2.py without touching this file.
+"""
+
+# ---------------------------------------------------------------------------
+# Tunable parameters
+# ---------------------------------------------------------------------------
+
+ALPHA_XYZ: float = 0.3
+"""EMA weight for XYZ coordinate smoothing. Lower = smoother but laggier."""
+
+ALPHA_WRIST: float = 0.4
+"""EMA weight for wrist roll/pitch angle smoothing."""
+
+GRAB_DEBOUNCE_FRAMES: int = 3
+"""Number of consecutive frames a grab state must hold before it is accepted."""
+
+
+# ---------------------------------------------------------------------------
+# EMA smoother — one instance per signal
+# ---------------------------------------------------------------------------
+
+class EMASmoother:
+    """
+    Single-axis Exponential Moving Average smoother.
+
+    Usage::
+
+        smoother = EMASmoother(alpha=0.3)
+        smoothed_x = smoother.update(raw_x)   # call once per frame
+        smoother.reset()                        # call when hand disappears
+    """
+
+    def __init__(self, alpha: float) -> None:
+        if not 0 < alpha <= 1:
+            raise ValueError(f"alpha must be in (0, 1], got {alpha}")
+        self._alpha = alpha
+        self._value: float | None = None
+
+    def update(self, raw: float) -> float:
+        """Feed a new raw measurement; return the smoothed value."""
+        if self._value is None:
+            self._value = raw          # first sample: no history yet
+        else:
+            self._value = self._alpha * raw + (1.0 - self._alpha) * self._value
+        return self._value
+
+    def reset(self) -> None:
+        """Discard history (call when the hand goes out of frame)."""
+        self._value = None
+
+    @property
+    def ready(self) -> bool:
+        """True once at least one sample has been fed."""
+        return self._value is not None
+
+
+# ---------------------------------------------------------------------------
+# XYZ bundle smoother
+# ---------------------------------------------------------------------------
+
+class XYZSmoother:
+    """
+    Three independent EMA smoothers for an XYZ coordinate dict.
+
+    Input / output shape::
+
+        {
+            "x": float, "y": float, "z": float | int,
+            "pixel_x": int, "pixel_y": int,   # passed through unchanged
+        }
+
+    "pixel_x" / "pixel_y" are the raw screen-space pixel positions used
+    for drawing overlays. They are NOT smoothed — smoothing pixel positions
+    would shift the drawn dot away from the actual detected hand centre.
+
+    Usage::
+
+        smoother = XYZSmoother()
+        smoothed = smoother.update(right_xyz)   # returns smoothed dict
+        smoother.reset()                         # call when right hand disappears
+    """
+
+    def __init__(self, alpha: float = ALPHA_XYZ) -> None:
+        self._x = EMASmoother(alpha)
+        self._y = EMASmoother(alpha)
+        self._z = EMASmoother(alpha)
+
+    def update(self, xyz: dict) -> dict:
+        """
+        Feed a raw XYZ dict; return a new dict with smoothed values.
+
+        "pixel_x" / "pixel_y" are passed through unchanged — they are pixel
+        positions used for drawing and should not be smoothed.
+        "z" is returned as int to preserve downstream compatibility.
+        """
+        return {
+            "x":       self._x.update(float(xyz["x"])),
+            "y":       self._y.update(float(xyz["y"])),
+            "z":       max(0, int(self._z.update(float(xyz["z"] or 0)))),  # clamp: z is never negative
+            "pixel_x": xyz["pixel_x"],   # pass through: used for draw overlay
+            "pixel_y": xyz["pixel_y"],   # pass through: used for draw overlay
+        }
+
+    def reset(self) -> None:
+        """Discard all history (call when the tracked hand disappears)."""
+        self._x.reset()
+        self._y.reset()
+        self._z.reset()
+
+
+# ---------------------------------------------------------------------------
+# Wrist angle smoother
+# ---------------------------------------------------------------------------
+
+class WristSmoother:
+    """
+    EMA smoother for the raw roll_delta and pitch_delta angles produced by
+    WristDetection.compute_wrist_state().
+
+    Smoothing is applied to the *numeric* deltas **before** classification
+    into Left/Right/Up/Down labels, so the thresholds in WristDetection act
+    on already-stable values.
+
+    Usage::
+
+        smoother = WristSmoother()
+        smoothed = smoother.update(raw_wrist_state)
+        smoother.reset()   # call when left hand disappears
+    """
+
+    def __init__(self, alpha: float = ALPHA_WRIST) -> None:
+        self._roll  = EMASmoother(alpha)
+        self._pitch = EMASmoother(alpha)
+
+    def update(self, wrist_state: dict) -> dict:
+        """
+        Feed a raw wrist_state dict from compute_wrist_state();
+        return a new dict with smoothed deltas and re-classified directions.
+        """
+        from WristDetection import classify_roll, classify_pitch  # avoid circular import at module level
+
+        smoothed_roll  = self._roll.update(wrist_state["roll_delta"])
+        smoothed_pitch = self._pitch.update(wrist_state["pitch_delta"])
+
+        return {
+            "roll_delta":      smoothed_roll,
+            "pitch_delta":     smoothed_pitch,
+            "roll_direction":  classify_roll(smoothed_roll),
+            "pitch_direction": classify_pitch(smoothed_pitch),
+        }
+
+    def reset(self) -> None:
+        """Discard history (call when the left hand disappears)."""
+        self._roll.reset()
+        self._pitch.reset()
+
+
+# ---------------------------------------------------------------------------
+# Grab debounce
+# ---------------------------------------------------------------------------
+
+class GrabDebouncer:
+    """
+    Suppresses single-frame grab flickers by requiring a state change to
+    hold for GRAB_DEBOUNCE_FRAMES consecutive frames before it is accepted.
+
+    Output is a string: ``"Grabbing"`` or ``"Open"``, matching the format
+    already used in main2.py.
+
+    Usage::
+
+        debouncer = GrabDebouncer()
+        stable_grab = debouncer.update(raw_grab_bool)  # "Grabbing" or "Open"
+        debouncer.reset()                               # call when hand disappears
+    """
+
+    def __init__(self, frames: int = GRAB_DEBOUNCE_FRAMES) -> None:
+        self._required = frames
+        self._pending_state: bool | None = None
+        self._pending_count: int = 0
+        self._confirmed_state: bool = False   # last confirmed state
+
+    def update(self, raw: bool) -> str:
+        """
+        Feed the raw boolean output of is_grabbing();
+        return the debounced state as ``"Grabbing"`` or ``"Open"``.
+        """
+        if raw == self._pending_state:
+            self._pending_count += 1
+            if self._pending_count >= self._required:
+                self._confirmed_state = raw
+        else:
+            # State changed — start counting from 1
+            self._pending_state = raw
+            self._pending_count = 1
+
+        return "Grabbing" if self._confirmed_state else "Open"
+
+    def reset(self) -> None:
+        """Discard all state (call when the hand disappears)."""
+        self._pending_state = None
+        self._pending_count = 0
+        self._confirmed_state = False


### PR DESCRIPTION
## Description
Adds src/smoothing.py and integrates it into src/main2.py to reduce jitter in MediaPipe hand-tracking output before it reaches the robot arm control pipeline.

## Related Issue or the ticket that you have been assigned (e.g fixes or closes #number-of-issue)
Closes https://github.com/sfu-akcse/Aether/issues/62
## Type of sections
- [✓] Computer Vision Node
- [ ] ROS 2 Communication
- [ ] Gazebo Simulation
- [ ] Socket Communication
- [ ] Firmware
- [ ] Mechanical Design
- [ ] Electrical Design
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Environment
- **Host OS:** Host OS: Windows 11 with WSL2
- **Container:** - [✓] Tested inside the standard Dev Container
- **Hardware:**
  - [✓] Tested with physical webcam
  - [ ] Tested with physical robot arm (Socket Comm)

## Testing (Explain testing approaches)
All testing was done manually by running python3 src/main2.py with a live webcam.

XYZ smoothing — Hold right hand still after pressing r to calibrate Z.
Confirm XYZ values in terminal output are stable and don't jitter frame-to-frame.

Smoother reset — Show right hand, hide it, show it again. Confirm XYZ jumps
immediately to the new position instead of drifting from the last seen position.

Raw vs smoothed — Confirm "raw" block appears in terminal output alongside
smoothed values. Run with LOG_RAW=false and confirm "raw" is null.

Out of scope

Wrist rotation and grab smoothing were considered but excluded from this PR
as the wrist calibration flow needs further investigation. (Temporarily filled in.)

Closes #62
XYZSmoother in src/smoothing.py is self-contained and can be extended
for wrist/grab smoothing in a follow-up PR

## Screenshots (if applicable)