### PR TITLE
implement side-view-z-axis-detection

### DIFF
--- a/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
+++ b/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
@@ -261,9 +261,9 @@ class CoordinatePublisher(Node):
             cv2.putText(image, "r = reset right-hand Z=0", (320, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
 
         if self.right_hand_z_side_base is None:
-            cv2.putText(image, "Press 'z' to set right-hand Z (side)=0", (400, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
+            cv2.putText(image, "Press 'z' to set right-hand Z (side)=0", (320, image.shape[0] - 60), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
         else:
-            cv2.putText(image, "z = reset right-hand Z (side)=0", (400, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
+            cv2.putText(image, "z = reset right-hand Z (side)=0", (320, image.shape[0] - 60), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
 
         # Terminal State replacement
         if self.right_xyz is not None:

--- a/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
+++ b/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
@@ -32,7 +32,10 @@ from .hand_tracker import (
     get_hand_label_position,
     draw_hand_name,
     draw_top_summary,
-    HAND_CONNECTIONS
+    HAND_CONNECTIONS,
+    calibrate_z_side,       
+    extract_z_side,         
+    draw_z_side_overlay,
 )
 
 class CoordinatePublisher(Node):
@@ -100,6 +103,7 @@ class CoordinatePublisher(Node):
         self.placeholder = np.zeros((480, 640, 3), dtype=np.uint8)
 
         self.right_hand_z_base = None
+        self.right_hand_z_side_base = None 
         self.left_hand_base_roll = None
         self.left_hand_base_pitch = None
 
@@ -201,6 +205,11 @@ class CoordinatePublisher(Node):
                 base_rotation_x(self.right_xyz, image)
 
             image = draw_z_overlay(image, right_z, right_z_box)
+
+            right_z_side = extract_z_side(right_hand, self.right_hand_z_side_base)
+            image = draw_z_side_overlay(image, right_z_side, right_hand)
+            if self.right_xyz is not None:
+                self.right_xyz["z_side"] = right_z_side
         else:
             cv2.putText(image, "Right Hand not detected", (20, image.shape[0] - 90), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
 
@@ -272,6 +281,9 @@ class CoordinatePublisher(Node):
             if key == ord("b") and left_state is not None:
                 left_hand = left_state.landmarks
                 self.left_hand_base_roll, self.left_hand_base_pitch = calibrate_wrist_base(left_hand, "Left")
+            if key == ord("z") and right_state is not None:  
+                right_hand = right_state.landmarks
+                self.right_hand_z_side_base = calibrate_z_side(right_hand)
             if key == ord("r") and right_state is not None:
                 right_hand = right_state.landmarks
                 _, self.right_hand_z_base, _ = extract_z_coordinate_for_hand(

--- a/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
+++ b/src/coordinate_processor/coordinate_processor/coordintate_publisher.py
@@ -33,8 +33,8 @@ from .hand_tracker import (
     draw_hand_name,
     draw_top_summary,
     HAND_CONNECTIONS,
-    calibrate_z_side,       
-    extract_z_side,         
+    calibrate_z_side,
+    extract_z_side,
     draw_z_side_overlay,
 )
 
@@ -103,7 +103,7 @@ class CoordinatePublisher(Node):
         self.placeholder = np.zeros((480, 640, 3), dtype=np.uint8)
 
         self.right_hand_z_base = None
-        self.right_hand_z_side_base = None 
+        self.right_hand_z_side_base = None
         self.left_hand_base_roll = None
         self.left_hand_base_pitch = None
 
@@ -206,9 +206,9 @@ class CoordinatePublisher(Node):
 
             image = draw_z_overlay(image, right_z, right_z_box)
 
-            right_z_side = extract_z_side(right_hand, self.right_hand_z_side_base)
+            right_z_side = extract_z_side(image, right_hand, self.right_hand_z_side_base)
             image = draw_z_side_overlay(image, right_z_side, right_hand)
-            if self.right_xyz is not None:
+            if self.right_xyz is not None and right_z_side is not None:
                 self.right_xyz["z_side"] = right_z_side
         else:
             cv2.putText(image, "Right Hand not detected", (20, image.shape[0] - 90), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
@@ -260,6 +260,11 @@ class CoordinatePublisher(Node):
         else:
             cv2.putText(image, "r = reset right-hand Z=0", (320, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
 
+        if self.right_hand_z_side_base is None:
+            cv2.putText(image, "Press 'z' to set right-hand Z (side)=0", (400, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
+        else:
+            cv2.putText(image, "z = reset right-hand Z (side)=0", (400, image.shape[0] - 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 2)
+
         # Terminal State replacement
         if self.right_xyz is not None:
             msg.x = float(self.right_xyz['x'])
@@ -281,9 +286,9 @@ class CoordinatePublisher(Node):
             if key == ord("b") and left_state is not None:
                 left_hand = left_state.landmarks
                 self.left_hand_base_roll, self.left_hand_base_pitch = calibrate_wrist_base(left_hand, "Left")
-            if key == ord("z") and right_state is not None:  
+            if key == ord("z") and right_state is not None:
                 right_hand = right_state.landmarks
-                self.right_hand_z_side_base = calibrate_z_side(right_hand)
+                self.right_hand_z_side_base = calibrate_z_side(image, right_hand)
             if key == ord("r") and right_state is not None:
                 right_hand = right_state.landmarks
                 _, self.right_hand_z_base, _ = extract_z_coordinate_for_hand(

--- a/src/coordinate_processor/coordinate_processor/hand_tracker.py
+++ b/src/coordinate_processor/coordinate_processor/hand_tracker.py
@@ -257,52 +257,73 @@ def extract_z_coordinate_for_hand(image, hand_landmarks, z_reset_flag, base_valu
     return max(0, z_offset), base_value, (min_x, min_y, max_x, max_y)
 
 
-def calibrate_z_side(hand_landmarks) -> float:
-    """
-    Save the current wrist depth as the Z = 0 base point for side-view detection.
+def _palm_width_px(image, hand_landmarks) -> float:
+    """Pixel distance between landmarks 5 (index MCP) and 17 (pinky MCP).
 
-    MediaPipe landmark.z is a depth value in roughly the same scale as landmark.x.
-    Call this once when the user signals their neutral hand position (e.g. on key press).
+    This grows as the hand moves toward the camera and shrinks as it moves
+    away, so it works as a depth proxy for a single, front-facing monocular
+    camera. hand_landmarks[0].z (wrist depth) can't be used for this because
+    MediaPipe defines landmark z relative to the wrist itself, so the
+    wrist's own z is always ~0 regardless of the hand's real distance from
+    the camera.
+    """
+    h, w, _ = image.shape
+    p_index_mcp = hand_landmarks[5]
+    p_pinky_mcp = hand_landmarks[17]
+    dx = (p_index_mcp.x - p_pinky_mcp.x) * w
+    dy = (p_index_mcp.y - p_pinky_mcp.y) * h
+    return (dx ** 2 + dy ** 2) ** 0.5
+
+
+def calibrate_z_side(image, hand_landmarks) -> float:
+    """
+    Save the current palm width (pixels) as the Z = 0 base point for
+    side-view detection.
+
+    Call this once when the user signals their neutral hand position
+    (e.g. on key press).
 
     Args:
+        image:          OpenCV BGR frame (needed to convert the normalized
+                         landmarks into a pixel distance).
         hand_landmarks: list of 21 NormalizedLandmark objects from MediaPipe.
 
     Returns:
-        The wrist landmark.z value to store as base_z.
+        The current palm-width value (pixels) to store as base_width.
     """
-    return hand_landmarks[0].z  # index 0 = wrist
+    return _palm_width_px(image, hand_landmarks)
 
 
-# How many normalized landmark units map to a Z output of 100.
-# Decrease to make Z more sensitive, increase to reduce sensitivity.
-Z_SIDE_FULL_SCALE = 0.3
+# How many pixels of palm-width change (relative to the calibrated base)
+# map to a Z output of 100. Tune by printing the delta for your own
+# camera/setup and moving your hand to the near/far limits you want to
+# represent.
+Z_SIDE_FULL_SCALE_PX = 80.0
 
 
-def extract_z_side(hand_landmarks, base_z: float | None) -> int | None:
+def extract_z_side(image, hand_landmarks, base_width: float | None) -> int | None:
     """
-    Compute the Z offset from the saved base point using wrist depth.
+    Compute the Z offset from the saved base point using palm width.
 
-    Unlike extract_z_coordinate_for_hand() (which uses palm bounding-box area),
-    this function uses the wrist landmark's depth value to detect actual
-    forward/backward movement:
-        positive → hand moved toward the camera (forward)
-        negative → hand moved away from the camera (backward)
-        None     → base point not yet set
+    positive → hand moved toward the camera (forward, palm looks bigger)
+    negative → hand moved away from the camera (backward, palm looks smaller)
+    None     → base point not yet set
 
     Args:
+        image:          OpenCV BGR frame.
         hand_landmarks: list of 21 NormalizedLandmark objects from MediaPipe.
-        base_z:         value returned by calibrate_z_side(). None if not yet set.
+        base_width:     value returned by calibrate_z_side(). None if not yet set.
 
     Returns:
-        Integer Z value (roughly -100 to +100), or None if not calibrated.
+        Integer Z value clamped to -100..100, or None if not calibrated.
     """
-    if base_z is None:
+    if base_width is None:
         return None
 
-    # MediaPipe z is negative toward the camera, so negate so that
-    # moving toward camera = positive Z (matches XY convention).
-    delta = -(hand_landmarks[0].z - base_z)
-    return int((delta / Z_SIDE_FULL_SCALE) * 100)
+    current_width = _palm_width_px(image, hand_landmarks)
+    delta = current_width - base_width
+    z_value = int((delta / Z_SIDE_FULL_SCALE_PX) * 100)
+    return max(-100, min(100, z_value))
 
 
 def draw_z_side_overlay(image, z_value, hand_landmarks) -> object:

--- a/src/coordinate_processor/coordinate_processor/hand_tracker.py
+++ b/src/coordinate_processor/coordinate_processor/hand_tracker.py
@@ -257,6 +257,87 @@ def extract_z_coordinate_for_hand(image, hand_landmarks, z_reset_flag, base_valu
     return max(0, z_offset), base_value, (min_x, min_y, max_x, max_y)
 
 
+def calibrate_z_side(hand_landmarks) -> float:
+    """
+    Save the current wrist depth as the Z = 0 base point for side-view detection.
+
+    MediaPipe landmark.z is a depth value in roughly the same scale as landmark.x.
+    Call this once when the user signals their neutral hand position (e.g. on key press).
+
+    Args:
+        hand_landmarks: list of 21 NormalizedLandmark objects from MediaPipe.
+
+    Returns:
+        The wrist landmark.z value to store as base_z.
+    """
+    return hand_landmarks[0].z  # index 0 = wrist
+
+
+# How many normalized landmark units map to a Z output of 100.
+# Decrease to make Z more sensitive, increase to reduce sensitivity.
+Z_SIDE_FULL_SCALE = 0.3
+
+
+def extract_z_side(hand_landmarks, base_z: float | None) -> int | None:
+    """
+    Compute the Z offset from the saved base point using wrist depth.
+
+    Unlike extract_z_coordinate_for_hand() (which uses palm bounding-box area),
+    this function uses the wrist landmark's depth value to detect actual
+    forward/backward movement:
+        positive → hand moved toward the camera (forward)
+        negative → hand moved away from the camera (backward)
+        None     → base point not yet set
+
+    Args:
+        hand_landmarks: list of 21 NormalizedLandmark objects from MediaPipe.
+        base_z:         value returned by calibrate_z_side(). None if not yet set.
+
+    Returns:
+        Integer Z value (roughly -100 to +100), or None if not calibrated.
+    """
+    if base_z is None:
+        return None
+
+    # MediaPipe z is negative toward the camera, so negate so that
+    # moving toward camera = positive Z (matches XY convention).
+    delta = -(hand_landmarks[0].z - base_z)
+    return int((delta / Z_SIDE_FULL_SCALE) * 100)
+
+
+def draw_z_side_overlay(image, z_value, hand_landmarks) -> object:
+    """
+    Draw the side-view Z value on the frame near the wrist landmark.
+
+    Args:
+        image:          OpenCV BGR frame.
+        z_value:        Value from extract_z_side(), or None if not calibrated.
+        hand_landmarks: list of 21 NormalizedLandmark objects from MediaPipe.
+
+    Returns:
+        Annotated image.
+    """
+    h, w, _ = image.shape
+    wrist_x = int(hand_landmarks[0].x * w)
+    wrist_y = int(hand_landmarks[0].y * h)
+
+    if z_value is None:
+        cv2.putText(
+            image,
+            "Press 'z' to set Z base",
+            (wrist_x + 10, wrist_y),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2,
+        )
+    else:
+        cv2.putText(
+            image,
+            f"Z (side): {z_value}",
+            (wrist_x + 10, wrist_y),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 200, 255), 2,
+        )
+    return image
+
+
 def draw_z_overlay(image, z_coordinate, z_box):
     if z_box is None:
         return image


### PR DESCRIPTION
## Description
Adds palm-width-based base-point calibration to `hand_tracker.py` and integrates it into `coordintate_publisher.py`, replacing the wrist-depth signal (always ~0 in MediaPipe).
## Related Issue or the ticket that you have been assigned (e.g fixes or closes #number-of-issue)
closes #68 
## Type of sections
- [✓] Computer Vision Node
- [ ] ROS 2 Communication
- [ ] Gazebo Simulation
- [ ] Socket Communication
- [ ] Firmware
- [ ] Mechanical Design
- [ ] Electrical Design
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Environment
- **Host OS:** Windows 11 with WSL2
- **Container:** - [✓] Tested inside the standard Dev Container
- **Hardware:**
  - [✓] Tested with physical webcam
  - [ ] Tested with physical robot arm (Socket Comm)

## Testing (Explain testing approaches)

- Tested with a physical webcam inside the standard Dev Container.
- Pressed z to set the current hand position as Z = 0.
- Moved the hand forward/backward and verified that the Z (side) value changed accordingly.
- Returned the hand to the base position and verified that the value returned near 0.

## Screenshots (if applicable)